### PR TITLE
Feature: Support SOCKS Authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ COPY . /httpRelay
 WORKDIR /httpRelay
 RUN make all
 
-FROM golang:1.21.0-alpine
+FROM alpine:3.18.3
 COPY --from=0 /httpRelay/proxy ./
 COPY --from=0 /httpRelay/relay ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21.0
+COPY . /httpRelay
+WORKDIR /httpRelay
+RUN make all
+
+FROM golang:1.21.0-alpine
+COPY --from=0 /httpRelay/proxy ./
+COPY --from=0 /httpRelay/relay ./

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Single-purpose HTTP proxy relaying requests to an existing (external) SOCKS 5 pr
 
 ## Usage
 
-`./relay -listen :8080 -socks localhost:8000 -block "127.0.0.1,localhost,192.168/16"`
+`./relay -listen :8080 -socks localhost:8000 -username username -password password -block "127.0.0.1,localhost,192.168.0.1/16"`
 
 Start a HTTP relay proxy that listens on port 8080 of every interface and connects to a SOCKS proxy server on localhost port 8000 for relaying your requests. Block requests that attempt to access 127.0.0.1, 'localhost' or any address in the ip range 192.168.0.0-192.168.255.255.
 
-`./proxy -listen localhost:8080 -block "127.0.0.1,localhost,192.168/16"`
+`./proxy -listen localhost:8080 -block "127.0.0.1,localhost,192.168.0.1/16"`
 
 Start a (tiny) generic HTTP proxy server that listens on port 8080 of 'localhost' and proxies requests directly to the internet. Block any requests to 127.0.0.1, 'localhost' or any address in the ip range 192.168.0.0-192.168.255.255.
 
@@ -25,6 +25,8 @@ The program arguments that are available to both programs.
 The following program arguments are applicable to `relay` only.
 
 - `-socks` the SOCKS proxy to which to forward http proxy requests.
+- `-username` the username of SOCKS5 proxy server.
+- `-password` the password of SOCKS5 proxy server.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Single-purpose HTTP proxy relaying requests to an existing (external) SOCKS 5 pr
 
 ## Usage
 
-`./relay -listen :8080 -socks localhost:8000 -username username -password password -block "127.0.0.1,localhost,192.168.0.1/16"`
+`./relay -listen :8080 -socks localhost:8000 -socks-user socksUsername -socks-pass socksPassword -block "127.0.0.1,localhost,192.168.0.1/16"`
 
 Start a HTTP relay proxy that listens on port 8080 of every interface and connects to a SOCKS proxy server on localhost port 8000 for relaying your requests. Block requests that attempt to access 127.0.0.1, 'localhost' or any address in the ip range 192.168.0.0-192.168.255.255.
 
@@ -25,8 +25,8 @@ The program arguments that are available to both programs.
 The following program arguments are applicable to `relay` only.
 
 - `-socks` the SOCKS proxy to which to forward http proxy requests.
-- `-username` the username of SOCKS5 proxy server.
-- `-password` the password of SOCKS5 proxy server.
+- `-socks-user` the username of SOCKS5 proxy server.
+- `-socks-pass` the password of SOCKS5 proxy server.
 
 ## Building
 

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	socksAddr := flag.String("socks", "localhost:8000", "Address and port of SOCKS5 proxy server.")
-	socksUsername := flag.String("username", "", "Username of SOCKS5 proxy server.")
-	socksPassword := flag.String("password", "", "Password of SOCKS5 proxy server.")
+	socksUsername := flag.String("socks-user", "", "Username of SOCKS5 proxy server.")
+	socksPassword := flag.String("socks-pass", "", "Password of SOCKS5 proxy server.")
 	listenAddr := flag.String("listen", ":8080", "Listening address and port for HTTP relay proxy.")
 	blockedAddrs := flag.String("block", "", "Comma-separated list of blocked host names, zone names, ip addresses and CIDR addresses.")
 	blocklist := flag.String("blocklist", "", "Filename referring to a hosts-formatted blocklist. (e.g. from energized.pro)")

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -12,12 +12,21 @@ import (
 
 func main() {
 	socksAddr := flag.String("socks", "localhost:8000", "Address and port of SOCKS5 proxy server.")
+	socksUsername := flag.String("username", "", "Username of SOCKS5 proxy server.")
+	socksPassword := flag.String("password", "", "Password of SOCKS5 proxy server.")
 	listenAddr := flag.String("listen", ":8080", "Listening address and port for HTTP relay proxy.")
 	blockedAddrs := flag.String("block", "", "Comma-separated list of blocked host names, zone names, ip addresses and CIDR addresses.")
 	blocklist := flag.String("blocklist", "", "Filename referring to a hosts-formatted blocklist. (e.g. from energized.pro)")
 	flag.Parse()
+	// Compose SOCKS auth
+	var auth *proxy.Auth
+	if *socksUsername != "" && *socksPassword != "" {
+		auth = new(proxy.Auth)
+		auth.User = *socksUsername
+		auth.Password = *socksPassword
+	}
 	// Prepare proxy relay with target SOCKS proxy
-	dialer, err := proxy.SOCKS5("tcp", *socksAddr, nil, proxy.Direct)
+	dialer, err := proxy.SOCKS5("tcp", *socksAddr, auth, proxy.Direct)
 	if err != nil {
 		log.Println("Failed to create proxy definition:", err.Error())
 		return


### PR DESCRIPTION
- Support SOCKS authentication. Add `username` and `password` arguments in relay mode.

Usage: `./relay -listen :8080 -socks localhost:8000 -username username -password password -block "127.0.0.1,localhost,192.168.0.1/16"`

- Change document to demonstrate this feature.
- Add `Dockerfile` to build docker image.